### PR TITLE
Added functionality for downloading spectrum image

### DIFF
--- a/cypress/integration/spectral-workbench-demo.spec.js
+++ b/cypress/integration/spectral-workbench-demo.spec.js
@@ -28,6 +28,8 @@ context('Actions', () => {
     cy.get('.bs-stepper-header>div').eq(6).not('have.class', 'active')
   });
 
+  const downloadsFolder = Cypress.config('downloadsFolder')
+
   it('can be clicked through to begin capturing', () => {
     cy.get('#landing-page-next').click()
     cy.get('#setting-page-next').click()

--- a/cypress/integration/spectral-workbench-demo.spec.js
+++ b/cypress/integration/spectral-workbench-demo.spec.js
@@ -44,7 +44,7 @@ context('Actions', () => {
     // so use "cy.readFile" to retry until the file exists
     // and has length - and we assume that it has finished downloading then
     cy.readFile(filename, { timeout: 15000 })
-    .should('have.length.gt', 50)
+    .should('have.length.gt', 5000000000)
   });
 
 })

--- a/cypress/integration/spectral-workbench-demo.spec.js
+++ b/cypress/integration/spectral-workbench-demo.spec.js
@@ -44,7 +44,7 @@ context('Actions', () => {
     // so use "cy.readFile" to retry until the file exists
     // and has length - and we assume that it has finished downloading then
     cy.readFile(filename, { timeout: 15000 })
-    .should('have.length.gt', 5000000000)
+    .should('have.length.gt', 50)
   });
 
 })

--- a/cypress/integration/spectral-workbench-demo.spec.js
+++ b/cypress/integration/spectral-workbench-demo.spec.js
@@ -1,4 +1,5 @@
 /// <reference types="cypress" />
+const path = require('path')
 
 context('Actions', () => {
 

--- a/cypress/integration/spectral-workbench-demo.spec.js
+++ b/cypress/integration/spectral-workbench-demo.spec.js
@@ -6,7 +6,6 @@ context('Actions', () => {
     cy.visit('http://127.0.0.1:8080/examples/new-capture/')
   })
 
-
   it('It reach the default landing page', () => {
     cy.get('#landing-page-content').contains('Spectral WorkBench');
     cy.get('#landing-page-content').contains('What is Spectral Workbench?');
@@ -28,5 +27,21 @@ context('Actions', () => {
     cy.get('.bs-stepper-header>div').eq(6).not('have.class', 'active')
   });
 
-  
+  it('can be clicked through to begin capturing', () => {
+    cy.get('#landing-page-next').click()
+    cy.get('#setting-page-next').click()
+    cy.get('#download-spectrum').click()
+
+    cy.log('**read downloaded file**')
+
+    // file path is relative to the working folder
+    const filename = path.join(downloadsFolder, 'spectrum_img.png')
+
+    // browser might take a while to download the file,
+    // so use "cy.readFile" to retry until the file exists
+    // and has length - and we assume that it has finished downloading then
+    cy.readFile(filename, { timeout: 15000 })
+    .should('have.length.gt', 50)
+  });
+
 })

--- a/examples/capture/capture.js
+++ b/examples/capture/capture.js
@@ -161,6 +161,27 @@ $W = {
     this_.getRecentCalibrations("#calibration_id");
   },
 
+  downloadSpectrum: function() {
+    function getFormattedTime() {
+      let current_date = new Date();
+      let year = current_date.getFullYear();
+      let month = current_date.getMonth() + 1;
+      let day = current_date.getDate();
+      let hours = current_date.getHours();
+      let minutes = current_date.getMinutes();
+      let seconds = current_date.getSeconds();
+      return (year + '-' + month + '-' + day + '-' + hours + '-' + minutes + '-' + seconds);
+    }
+
+  let base64_imgdata = $('#dataurl').val($W.canvas.toDataURL())[0].defaultValue;
+  console.log(base64_imgdata);
+
+  let a = document.createElement('a');
+  a.href = base64_imgdata;
+  a.download = ('spectrum_img-' + getFormattedTime() + '.png');
+  a.click();
+  },
+
   getRecentCalibrations: function(selector) {
     $.ajax({
       url: "/capture/recent_calibrations.json?calibration_id=" + $W.calibration_id,

--- a/examples/capture/capture.js
+++ b/examples/capture/capture.js
@@ -162,23 +162,12 @@ $W = {
   },
 
   downloadSpectrum: function() {
-    function getFormattedTime() {
-      let current_date = new Date();
-      let year = current_date.getFullYear();
-      let month = current_date.getMonth() + 1;
-      let day = current_date.getDate();
-      let hours = current_date.getHours();
-      let minutes = current_date.getMinutes();
-      let seconds = current_date.getSeconds();
-      return (year + '-' + month + '-' + day + '-' + hours + '-' + minutes + '-' + seconds);
-    }
-
   let base64_imgdata = $('#dataurl').val($W.canvas.toDataURL())[0].defaultValue;
   console.log(base64_imgdata);
 
   let a = document.createElement('a');
   a.href = base64_imgdata;
-  a.download = ('spectrum_img-' + getFormattedTime() + '.png');
+  a.download = ('spectrum_img.png');
   a.click();
   },
 

--- a/examples/capture/index.html
+++ b/examples/capture/index.html
@@ -174,7 +174,11 @@
         <a rel="tooltip" title="Flip video horizontally" class="btn btn-default btn-flip" onClick="$W.flip_horizontal()"><i class="fa fa-white fa-arrows-h"></i></a>
         <a rel="tooltip" title="Scale video" class="btn btn-default" onClick="$W.scale_h = parseFloat(prompt('Enter a horizontal scaling factor (default is 1):'))"><i class="fa fa-white fa-expand"></i></a>
       </div>
- 
+
+      <div class="select" style="padding-top:5px;">
+        <label for="videoSource">Camera source: </label><select id="videoSource"></select>
+      </div>
+
       <p><small><b>TOOLS</b></small></p>
       <div class="btn-group toolbar" style="margin-bottom:5px;">
         <a rel="tooltip" title="Scripting" class="btn btn-default" href="#macros" data-toggle="tab"><i class="fa fa-white fa-terminal"></i></a>

--- a/examples/new-capture/index.html
+++ b/examples/new-capture/index.html
@@ -170,8 +170,12 @@
             <a rel="tooltip" title="" class="btn btn-default" onclick="$W.auto_detect_sample_row()" data-original-title="Auto select sample row"><i class="fa fa-white fa-arrows-v"></i> Auto-select Sample Row</a>
             <a rel="tooltip" title="Flip video horizontally" class="btn btn-default btn-flip" onClick="$W.flip_horizontal()"><i class="fa fa-white fa-arrows-h"></i> Flip image</a>
             <a rel="tooltip" title="Rotate video 90 &deg;" class="btn btn-default btn-rotate" onClick="$W.toggle_rotation()"><i class="fa fa-white fa-rotate-right"></i> Rotate</a>
-
           </p>
+
+          <div class="select" style="padding-top:5px;">
+            <label for="videoSource">Camera source: </label><select id="videoSource"></select>
+          </div>
+
           <p style="padding-top:5px;">
             Help <a href="http://publiclab.org/wiki/spectral-workbench-usage#Webcam+selection">selecting a camera</a>
           </p>
@@ -242,9 +246,14 @@
           </div>
         </div>
 
+        <input name="dataurl" type="hidden" id="dataurl" />
+
         <button class="demo-button next" id="capture-page-next">Save Capture</button>
         <p style="margin-top: 0.5em">Once you save the capture, you cannot go back here.</p>
         <img style="display:none;background:#333;" id="spectrum-preview" />
+
+        <button class="demo-button next" id="download-spectrum" onClick="$W.downloadSpectrum();">Download</button>
+
       </div>
 
 


### PR DESCRIPTION
The current `Download` button at http://spectralworkbench.org doesn't work. A blank page is open instead. The added function could be utilised wherever possible for example in the new interface to download the spectrum images with the timestamp. Here's a demo for the same: 


https://user-images.githubusercontent.com/58583793/128475067-207d9b0b-aa51-4c88-8448-e670d6284ade.mov



* [ ] tests pass -- see README.md for how to run them
* [ ] code is in uniquely-named feature branch, and has been rebased on top of latest master (especially if you've been asked to make additional changes)
* [ ] pull request are descriptively named
* [ ] if possible, multiple commits squashed if they're smaller changes
* [ ] reviewed/confirmed/tested by another contributor or maintainer

Please be sure you've reviewed our contribution guidelines at https://publiclab.org/wiki/contributing-to-public-lab-software

Please alert developers on plots-dev@googlegroups.com when your request is ready or if you need assistance.

Thanks!
