### PR TITLE
Camera switching in a dropdown list

### DIFF
--- a/examples/capture/index.html
+++ b/examples/capture/index.html
@@ -174,6 +174,10 @@
         <a rel="tooltip" title="Flip video horizontally" class="btn btn-default btn-flip" onClick="$W.flip_horizontal()"><i class="fa fa-white fa-arrows-h"></i></a>
         <a rel="tooltip" title="Scale video" class="btn btn-default" onClick="$W.scale_h = parseFloat(prompt('Enter a horizontal scaling factor (default is 1):'))"><i class="fa fa-white fa-expand"></i></a>
       </div>
+
+      <div class="select" style="padding-top:5px;">
+        <label for="videoSource">Camera source: </label><select id="videoSource"></select>
+      </div>
  
       <p><small><b>TOOLS</b></small></p>
       <div class="btn-group toolbar" style="margin-bottom:5px;">

--- a/examples/new-capture/index.html
+++ b/examples/new-capture/index.html
@@ -170,8 +170,12 @@
             <a rel="tooltip" title="" class="btn btn-default" onclick="$W.auto_detect_sample_row()" data-original-title="Auto select sample row"><i class="fa fa-white fa-arrows-v"></i> Auto-select Sample Row</a>
             <a rel="tooltip" title="Flip video horizontally" class="btn btn-default btn-flip" onClick="$W.flip_horizontal()"><i class="fa fa-white fa-arrows-h"></i> Flip image</a>
             <a rel="tooltip" title="Rotate video 90 &deg;" class="btn btn-default btn-rotate" onClick="$W.toggle_rotation()"><i class="fa fa-white fa-rotate-right"></i> Rotate</a>
-
           </p>
+
+          <div class="select" style="padding-top:5px;">
+            <label for="videoSource">Camera source: </label><select id="videoSource"></select>
+          </div>
+          
           <p style="padding-top:5px;">
             Help <a href="http://publiclab.org/wiki/spectral-workbench-usage#Webcam+selection">selecting a camera</a>
           </p>


### PR DESCRIPTION
Camera switching workflow for video stream: 

- Get all the possible devices in a dropdown
- For each `deviceId` associate a video stream 
- On device change through dropdown, stop the current stream and switch to the newly selected stream

Hi @jywarren, the current implementation is such that it takes the initial `facingMode` as `undefined`, since the devices have not been fetched yet. 

```javascript

 var constraints = {
        video: {
          deviceId: videoSource ? {exact: videoSource} : undefined //Taking device ids as the video source 
        }
      };

```

Even after fetching, it is unclear as to what device is facing the `environment` since some devices don't actually have a facingMode as `environment`. The MDN docs recommend using it for [smartphones](https://developer.mozilla.org/en-US/docs/Web/API/MediaTrackConstraints/facingMode). 
For instance if a laptop is connected to an external camera, that external camera is recognised as a `facingMode = environment` instead of the primary one.

Thus, I wanted to know your thoughts regarding this...

Make sure these boxes are checked before your pull request is ready to be reviewed and merged. Thanks!

* [ ] tests pass -- see README.md for how to run them
* [ ] code is in uniquely-named feature branch, and has been rebased on top of latest master (especially if you've been asked to make additional changes)
* [ ] pull request are descriptively named
* [ ] if possible, multiple commits squashed if they're smaller changes
* [ ] reviewed/confirmed/tested by another contributor or maintainer

Please be sure you've reviewed our contribution guidelines at https://publiclab.org/wiki/contributing-to-public-lab-software

Please alert developers on plots-dev@googlegroups.com when your request is ready or if you need assistance.

Thanks!
